### PR TITLE
fix JointTransform2D applied to train dataset

### DIFF
--- a/train.py
+++ b/train.py
@@ -84,7 +84,7 @@ else:
 
 tf_train = JointTransform2D(crop=crop, p_flip=0.5, color_jitter_params=None, long_mask=True)
 tf_val = JointTransform2D(crop=crop, p_flip=0, color_jitter_params=None, long_mask=True)
-train_dataset = ImageToImage2D(args.train_dataset, tf_val)
+train_dataset = ImageToImage2D(args.train_dataset, tf_train)
 val_dataset = ImageToImage2D(args.val_dataset, tf_val)
 predict_dataset = Image2D(args.val_dataset)
 dataloader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=True)


### PR DESCRIPTION
In train script, there are two JointTransform2D instances while only `tf_val` is used for both train/val datasets. It seems that `tf_train` need to be applied for the train datasets.